### PR TITLE
Update to ubuntu-latest in pre-commit_autoupdate.yml

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   auto-update:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
# Description

Ubuntu 20.04 is being retired as a runner image from GitHub Actions. See https://github.com/actions/runner-images/issues/11101

This PR changes the runner to `ubuntu-latest`.