### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ To get started:
    pre-commit install
    ```
 
+1. Specify the location of your cluster configuration file:
+
+   ```bash
+   export CARBON_CONFIG=/path/to/config.yaml
+   ```
+
 1. Run the main app:
 
    ```bash


### PR DESCRIPTION
# Description

Removed user section of readme. For now there is no separate instructions for users. I'll add these in later when there is an alternative path for users (which will probably involve loading the pre-installed tool on the cluster login nodes via Lmod).

Added a step to specify the `CARBON_CONFIG` enviroment variable in the developer instructions.

Fixes #74
Fixes #75