### PR TITLE
Use job state

### DIFF
--- a/carbon/__main__.py
+++ b/carbon/__main__.py
@@ -100,7 +100,7 @@ def main(job_id: str, compare: bool, verbose: bool, config_path: str) -> None:
             sys.exit()
         except JobStateError as e:
             print(f"Error: {e}")
-            sys.exit
+            sys.exit()
         node = Node.fromPBS(
             job.node,
             {

--- a/carbon/job.py
+++ b/carbon/job.py
@@ -140,7 +140,7 @@ class Job:
         state = job_data["Jobs"][internal_id]["job_state"]
         if not (state == "F" or state == "R"):
             raise JobStateError(
-                f"Analysis of jobs with job state {state} is not "
+                f"Analysis of jobs with state {state} is not "
                 "currently supported. Please specify a running (R) or "
                 "finished (F) job."
             )


### PR DESCRIPTION
- Don't attempt to analyse jobs with job states other than R (running), or F (finished). Other job states (such as Queued) may not have a `resources_used` key in the `job_data` library.
- Warn the user if they are analysing a R (running) job.

Fixes #119
Fixes #118