### PR TITLE
prefix 'pre-commit install' with 'uv run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To get started:
 1. Install the git hooks:
 
    ```bash
-   pre-commit install
+   uv run pre-commit install
    ```
 
 1. [Activate the virtual environment](https://docs.astral.sh/uv/pip/environments/#using-a-virtual-environment)


### PR DESCRIPTION
# Description

This PR updates the developer instructions in the README, so that the `pre-commit install` instruction is prefixed with `uv run` for successful installation of pre-commit hooks.

Fixes #170 

## Type of change

- [X] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [X] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
