### PR TITLE
Fix the issue #162: Hardcoded average carbon intensity

### DIFF
--- a/carbon/__main__.py
+++ b/carbon/__main__.py
@@ -38,12 +38,9 @@ def main(
         compare (bool): If True, compare emissions to other activities.
         verbose (bool): If True, provide verbose output.
         config_path (str): Path to the cluster configuration file.
-    <<<<<<< HEAD
         default_intensity (bool): If True, use a default carbon intensity value.
 
-    =======
     \b
-    >>>>>>> upstream/main
     Returns:
         None
     """


### PR DESCRIPTION
# Description

Add an option to use the hardcoded average carbon intensity (137 gCO2/kWh)

When the carbon intensity API or network is unavailable or slow, users can use a hardcoded average value instead of waiting/failing. The default value (137 gCO2/kWh) is calculated as the average of UK's yearly carbon intensity for 2023 (149 gCO2/kWh) and 2024 (124 gCO2/kWh). 

- References: 
  - 2024: 124 gCO2/kWh (https://www.neso.energy/news/britains-electricity-explained-2024-review)
  - 2023: 149 gCO2/kWh (https://www.neso.energy/news/britains-electricity-explained-2023-review)

Fixes #162 (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
