### PR TITLE
Correct emssions units from gCO2e to gCO2

### DIFF
--- a/carbon/__init__.py
+++ b/carbon/__init__.py
@@ -83,7 +83,7 @@ def run(
 
     # Fetch carbon intensity at job start time or use a default value
     if default_intensity:
-        intensity = 137.0  # gCO2e/kWh, UK average over 2023 and 2024
+        intensity = 137.0  # gCO2/kWh, UK average over 2023 and 2024
     else:
         carbon_intensity = CarbonIntensity(job.starttime, region_id=config.region_id)
         intensity = carbon_intensity.fetch()

--- a/carbon/__main__.py
+++ b/carbon/__main__.py
@@ -26,7 +26,7 @@ from carbon import run
 @click.option(
     "--default_intensity",
     is_flag=True,
-    help="Use a default value for the carbon intensity (137 gCO2e/kWh)",
+    help="Use a default value for the carbon intensity (137 gCO2/kWh)",
 )
 @click.argument("job_id", type=str)
 def main(
@@ -106,7 +106,7 @@ def main(
             f"\n    GPU power draw (per GPU): {node.per_gpu_power_watts} W"
             f"\n    Memory power draw (per GB): {node.per_gb_power_watts} W"
             f"\nCalculation information:"
-            f"\n    Estimate is for scope 2 emissions only "
+            f"\n    Estimate is for scope 2 CO2 emissions only "
             f"(i.e., indirect emissions due to purchased electricity)."
             f"\n    Estimate is performed AS IF carbon intensity was London average at "
             f"job start time, although electricity to Imperial's clusters is certified "
@@ -126,10 +126,10 @@ def main(
         f"is {energy_consumed:.2f} kWh"
     )
     if default_intensity:
-        print(f"Using UK average carbon intensity of {intensity} gCO2e/kWh")
+        print(f"Using UK average carbon intensity of {intensity} gCO2/kWh")
     else:
-        print(f"Carbon intensity for {job.starttime} is {intensity} gCO2e/kWh")
-    print(f"Estimated emissions is {round(emissions)} gCO2e")
+        print(f"Carbon intensity for {job.starttime} is {intensity} gCO2/kWh")
+    print(f"Estimated emissions is {round(emissions)} gCO2")
 
     # Do comparisons if requested
     if compare:

--- a/carbon/comparisons.py
+++ b/carbon/comparisons.py
@@ -40,8 +40,7 @@ class EmissionsComparison(ABC):
         """Calculates the amount of each item that would emit the same emissions.
 
         Args:
-            emissions_gco2 (float): The emissions in grams of CO2 equivalent to compare
-                against.
+            emissions_gco2 (float): The emissions in grams of CO2 to compare against.
 
         Returns:
             list[tuple[str, float, str]]: List of (item, amount, unit/note) tuples.
@@ -53,8 +52,7 @@ class EmissionsComparison(ABC):
         """Print the equivalent of each item for the given emissions.
 
         Args:
-            emissions_gco2 (float): The emissions in grams of CO2 equivalent to compare
-                against.
+            emissions_gco2 (float): The emissions in grams of CO2 to compare against.
         """
         pass
 
@@ -66,8 +64,7 @@ class Travel(EmissionsComparison):
         """Calculates the distance via each method that would emit the same emissions.
 
         Args:
-            emissions_gco2 (float): The emissions in grams of CO2 equivalent to compare
-                against.
+            emissions_gco2 (float): The emissions in grams of CO2 to compare against.
 
         Returns:
             list[tuple[str, float, str]]: List of (method, kilometers, note) tuples.
@@ -85,8 +82,7 @@ class Travel(EmissionsComparison):
         """Print the equivalent travel distances for the given emissions.
 
         Args:
-            emissions_gco2 (float): The emissions in grams of CO2 equivalent to compare
-                against.
+            emissions_gco2 (float): The emissions in grams of CO2 to compare against.
         """
         equivalents = self.get_equivalents(emissions_gco2)
         print("Equivalent to:")
@@ -101,8 +97,7 @@ class Food(EmissionsComparison):
         """Calculate the number of portions that would emit the same emissions.
 
         Args:
-            emissions_gco2 (float): The emissions in grams of CO2 equivalent to compare
-                against.
+            emissions_gco2 (float): The emissions in grams of CO2 to compare against.
 
         Returns:
             list[tuple[str, float, str]]: List of (food, portions, portion_name) tuples.
@@ -121,8 +116,7 @@ class Food(EmissionsComparison):
         """Print the equivalent food portions for the given emissions.
 
         Args:
-            emissions_gco2 (float): The emissions in grams of CO2 equivalent to compare
-                against.
+            emissions_gco2 (float): The emissions in grams of CO2 to compare against.
         """
         equivalents = self.get_equivalents(emissions_gco2)
         print("Equivalent to:")


### PR DESCRIPTION
The carbon intensity API provides values in gCO2/kWh NOT gCO2e/kWh (CO2-equivalent). In other words, greenhouse gas emissions other than CO2 are actually neglected (although they probably shouldnt be!), rather than converted. I've updated the units in the code to reflect this.