### PR TITLE
Rename flag --default_intensity to --average-intensity

### DIFF
--- a/carbon/__init__.py
+++ b/carbon/__init__.py
@@ -25,14 +25,14 @@ class RunResult:
 
 
 def run(
-    job_id: str, config: ClusterConfig, default_intensity: bool = False
+    job_id: str, config: ClusterConfig, average_intensity: bool = False
 ) -> RunResult:
     """Estimate the carbon emissions of a compute job.
 
     Args:
         job_id (str): The job identifier to analyze.
         config (ClusterConfig): The cluster configuration.
-        default_intensity (bool): If True, use a default carbon intensity value.
+        average_intensity (bool): If True, use an average carbon intensity value.
 
     Returns:
         RunResult: The results of the carbon calculation.
@@ -82,7 +82,7 @@ def run(
     energy_consumed = job.calculate_energy(node, config.pue)
 
     # Fetch carbon intensity at job start time or use a default value
-    if default_intensity:
+    if average_intensity:
         intensity = 137.0  # gCO2/kWh, UK average over 2023 and 2024
     else:
         carbon_intensity = CarbonIntensity(job.starttime, region_id=config.region_id)

--- a/carbon/__main__.py
+++ b/carbon/__main__.py
@@ -24,13 +24,13 @@ from carbon import run
     help="Path to the cluster configuration file.",
 )
 @click.option(
-    "--default_intensity",
+    "--average-intensity",
     is_flag=True,
     help="Use a default value for the carbon intensity (137 gCO2/kWh)",
 )
 @click.argument("job_id", type=str)
 def main(
-    job_id: str, compare: bool, verbose: bool, config_path: str, default_intensity: bool
+    job_id: str, compare: bool, verbose: bool, config_path: str, average_intensity: bool
 ) -> None:
     """Estimate and display the carbon emissions of a compute job.
 
@@ -40,7 +40,7 @@ def main(
         compare (bool): If True, compare emissions to other activities.
         verbose (bool): If True, provide verbose output.
         config_path (str): Path to the cluster configuration file.
-        default_intensity (bool): If True, use a default carbon intensity value.
+        average_intensity (bool): If True, use a default carbon intensity value.
 
     \b
     Returns:
@@ -75,7 +75,7 @@ def main(
 
     # Run the carbon calculation
     try:
-        result = run(job_id, config, default_intensity=default_intensity)
+        result = run(job_id, config, default_intensity=average_intensity)
     except (UnknownJobIDError, MalformedJobIDError) as e:
         print(f"Error: {e}. Please check the job ID.")
         sys.exit(1)
@@ -125,7 +125,7 @@ def main(
         f"and {memhours:.2f} GB-hours "
         f"is {energy_consumed:.2f} kWh"
     )
-    if default_intensity:
+    if average_intensity:
         print(f"Using UK average carbon intensity of {intensity} gCO2/kWh")
     else:
         print(f"Carbon intensity for {job.starttime} is {intensity} gCO2/kWh")

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -71,7 +71,7 @@ The start time of the job is used for the timestamp for which $I$ is fetched.
 
 Note that only CO2 emissions from electricity generation are reported by the API, meaning that other greenhouse gas emissions are neglected, along with other emissions due to indirect effects such as changes in land use.
 
-The API call can be skipped in favour of a hardcoded default intensity using the flag `--default_intensity`.
+The API call can be skipped in favour of a hardcoded default intensity using the flag `--average-intensity`.
 The default carbon intensity (137 CO2/kWh) is based on an average of the UK's intensity over 2023 (149 CO2/kWh) and 2024 (125 CO2/kWh) (see [Sources](sources.md#uk-average-carbon-intensities)).
 
 ToDo: Link to separate doc with details about renewable energy certification (REGOs?).


### PR DESCRIPTION
Replaced all instances of '--default_intensity' with '--average-intensity' for clearer terminology and consistent flag naming.
