### PR TITLE
Fix crash when job never started due to insufficient resources

### DIFF
--- a/carbon/job/factories.py
+++ b/carbon/job/factories.py
@@ -332,6 +332,15 @@ class PBSJobFactory(JobFactory):
                 # If the job ran on multiple nodes (e.g., using MPI),
                 # just take the first one. This will be used to get the cpu_type
                 # and gpu_type, which should be the same across the nodes.
+
+                comment = job_data["Jobs"][internal_id].get("comment", "")
+                if "Not Running" in comment:
+                    if ignore_failed:
+                        continue
+                    else:
+                        raise JobStateError(
+                            f"Job {internal_id} never started. Comment: '{comment}'"
+                        )
                 nodes = [
                     name.split("/", 1)[0]
                     for name in job_data["Jobs"][internal_id]["exec_host"].split("+")


### PR DESCRIPTION
# Description

When a job fails to start, PBS marks it as finished (F) but never assigns it an exec_host. Carbon would crash with a `KeyError` trying to read that field. The code checks the comment field for "Not Running" and raises a clean` JobStateError `instead.

Fixes #194 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
