### PR TITLE
Add PyInstaller build step to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,14 @@ jobs:
       - name: Check that documentation builds cleanly with MkDocs
         if: matrix.os == 'ubuntu-latest'
         run: uv run mkdocs build --strict
+
+      - name: Build the executable
+        if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
+        run: uv run pyinstaller carbon.spec
+
+      - name: upload artifact
+        if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v7
+        with:
+          name: carbon
+          path: dist/carbon

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,11 @@ jobs:
         run: uv run mkdocs build --strict
 
       - name: Build the executable
-        if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
+        if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
         run: uv run pyinstaller carbon.spec
 
       - name: upload artifact
-        if: github.ref == 'refs/heads/master' && matrix.os == 'ubuntu-latest'
+        if: github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v7
         with:
           name: carbon


### PR DESCRIPTION
# Description

Added a build and upload step to the existing CI workflow that runs PyInstaller and uploads the resulting a artifact

Fixes #231 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
