### PR TITLE
Fix README: Add missing `--all-groups` flag to `uv sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To get started:
 1. Set up the virtual environment:
 
    ```bash
-   uv sync
+   uv sync --all-groups
    ```
 
 1. Install the git hooks:


### PR DESCRIPTION
# Description

As the instructions in the README are aimed at developers, they should be running `uv sync --all-groups` so that they also get the dependencies in the `dev` and `docs` groups. Fix this.

See also: https://github.com/ImperialCollegeLondon/python-template/pull/550
## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
