### PR TITLE
Add CSV exporter

### DIFF
--- a/carbon/__main__.py
+++ b/carbon/__main__.py
@@ -72,7 +72,6 @@ def get_exporter_classes() -> dict[str, type[Exporter]]:
     type=click.Path(),
     help="Path to the cluster configuration file.",
 )
-@click.option("--exporter", type=str, default=None, help="Export results csv file")
 @click.option(
     "--average-intensity",
     is_flag=True,
@@ -99,7 +98,6 @@ def main(
     average_intensity: bool,
     split_jobs: bool,
     ignore_failed: bool,
-    exporter: str | None,
 ) -> None:
     """Estimate and display the carbon emissions of a compute job.
 
@@ -207,10 +205,7 @@ def main(
             )
             break
 
-    exporters_to_run = list(config.exporters)
-    if exporter and exporter not in exporters_to_run:
-        exporters_to_run.append(exporter)
-    for name in exporters_to_run:
+    for name in config.exporters:
         exporter_class = get_exporter_classes().get(name)
         if exporter_class is None:
             print(f"Error: Unknown exporter {name}")

--- a/carbon/__main__.py
+++ b/carbon/__main__.py
@@ -208,7 +208,7 @@ def main(
             break
 
     exporters_to_run = list(config.exporters)
-    if exporter:
+    if exporter and exporter not in exporters_to_run:
         exporters_to_run.append(exporter)
     for name in exporters_to_run:
         exporter_class = get_exporter_classes().get(name)

--- a/carbon/__main__.py
+++ b/carbon/__main__.py
@@ -210,7 +210,7 @@ def main(
         if exporter_class is None:
             print(f"Error: Unknown exporter {name}")
             sys.exit(1)
-        exporter_class.from_config({}).export(results)
+        exporter_class.from_config(config.exporter_config.get(name, {})).export(results)
 
     # Warn if any jobs failed to be analysed
     if failed_count > 0:

--- a/carbon/__main__.py
+++ b/carbon/__main__.py
@@ -13,6 +13,7 @@ import click
 
 from carbon import RunResult, run
 from carbon.clusterconfig import ClusterConfig
+from carbon.exporter import CSVExporter, Exporter
 from carbon.job.factories import (
     DummyJobFactory,
     FileJobFactory,
@@ -53,6 +54,11 @@ def get_job_factory_classes() -> dict[str, type[JobFactory]]:
     return factories
 
 
+def get_exporter_classes() -> dict[str, type[Exporter]]:
+    """Get available exporter classes."""
+    return dict(csv=CSVExporter)
+
+
 @click.command()
 @click.option("-v", "--verbose", is_flag=True, help="Enables verbose output")
 @click.option(
@@ -66,6 +72,7 @@ def get_job_factory_classes() -> dict[str, type[JobFactory]]:
     type=click.Path(),
     help="Path to the cluster configuration file.",
 )
+@click.option("--exporter", type=str, default=None, help="Export results csv file")
 @click.option(
     "--average-intensity",
     is_flag=True,
@@ -92,6 +99,7 @@ def main(
     average_intensity: bool,
     split_jobs: bool,
     ignore_failed: bool,
+    exporter: str | None,
 ) -> None:
     """Estimate and display the carbon emissions of a compute job.
 
@@ -198,6 +206,16 @@ def main(
                 "completed portion of the job and may not reflect total emissions."
             )
             break
+
+    exporters_to_run = list(config.exporters)
+    if exporter:
+        exporters_to_run.append(exporter)
+    for name in exporters_to_run:
+        exporter_class = get_exporter_classes().get(name)
+        if exporter_class is None:
+            print(f"Error: Unknown exporter {name}")
+            sys.exit(1)
+        exporter_class.from_config({}).export(results)
 
     # Warn if any jobs failed to be analysed
     if failed_count > 0:

--- a/carbon/clusterconfig.py
+++ b/carbon/clusterconfig.py
@@ -68,3 +68,4 @@ class ClusterConfig(BaseModel):  # type: ignore[explicit-any]
     scheduler: str
     scheduler_config: dict[str, Any]  # type: ignore[explicit-any]
     average_intensity: NonNegativeFloat | None = None
+    exporters: list[str] = []

--- a/carbon/clusterconfig.py
+++ b/carbon/clusterconfig.py
@@ -79,3 +79,4 @@ class ClusterConfig(BaseModel):  # type: ignore[explicit-any]
     scheduler_config: dict[str, Any]  # type: ignore[explicit-any]
     average_intensity: NonNegativeFloat | None = None
     exporters: list[str] = []
+    exporter_config: dict[str, dict[str, Any]] = Field(default_factory=dict)  # type: ignore[explicit-any]

--- a/carbon/clusterconfig.py
+++ b/carbon/clusterconfig.py
@@ -43,6 +43,16 @@ class FileSchedulerConfig(BaseModel):
     node_data_file_path: Path
 
 
+class CSVExporterConfig(BaseModel):
+    """Configuration for exporting results to CSV files.
+
+    Attributes:
+        output_path (Path): Path where CSV output will be saved.
+    """
+
+    output_path: Path = Path("carbon_output.csv")
+
+
 class ClusterConfig(BaseModel):  # type: ignore[explicit-any]
     """Configuration for an HPC cluster and hosting data center.
 

--- a/carbon/exporter.py
+++ b/carbon/exporter.py
@@ -6,8 +6,10 @@ specified region and time period.
 """
 
 import csv
+import os
 from abc import abstractmethod
-from typing import Any, Protocol, Self
+from typing import Protocol, Self
+
 from carbon import RunResult
 
 
@@ -17,13 +19,14 @@ class Exporter(Protocol):
     @classmethod
     @abstractmethod
     def from_config(cls, config: dict[str, object]) -> Self:
-        """Create an instance of the class from a cofiguration data"""
+        """Create an instance of the class from a configuration data."""
 
     @abstractmethod
     def export(self, run_result: list[RunResult]) -> None:
-        """Export the results
+        """Export the results to a CSV file, one row per job.
+
         Args:
-            run_result (list[RunResult]): The results to export
+            run_result (list[RunResult]): The results to export.
         """
 
 
@@ -40,16 +43,36 @@ class CSVExporter(Exporter):
 
     @classmethod
     def from_config(cls, config: dict[str, object]) -> Self:
-        """Create a CSVExporter from congiguration data."""
+        """Create a CSVExporter from configuration data."""
         return cls(output_path=str(config.get("output_path", "carbon_output.csv")))
 
     def export(self, run_result: list[RunResult]) -> None:
-        """Export the results to a CSV file. one row per job
+        """Export the results.
+
         Args:
-            run_result (list[RunResult]): The results to export
+            run_result (list[RunResult]): The results to export.
         """
+        file_exists = (
+            os.path.exists(self.output_path) and os.path.getsize(self.output_path) > 0
+        )
+
         with open(self.output_path, "a", newline="") as csvfile:
             writer = csv.writer(csvfile)
+            if not file_exists:
+                writer.writerow(
+                    [
+                        "job_id",
+                        "starttime",
+                        "runtime",
+                        "cputime",
+                        "gputime",
+                        "memtime",
+                        "node",
+                        "energy_consumed",
+                        "carbon_intensity",
+                        "emissions",
+                    ]
+                )
             for result in run_result:
                 writer.writerow(
                     [

--- a/carbon/exporter.py
+++ b/carbon/exporter.py
@@ -1,0 +1,67 @@
+"""The carbon exporter module.
+
+This module provides functionality to fetch and display carbon intensity data.
+Data is fetched from the Carbon Intensity API (carbonintensity.org.uk) based on the
+specified region and time period.
+"""
+
+import csv
+from abc import abstractmethod
+from typing import Any, Protocol, Self
+from carbon import RunResult
+
+
+class Exporter(Protocol):
+    """Abstract base class for Exporters."""
+
+    @classmethod
+    @abstractmethod
+    def from_config(cls, config: dict[str, object]) -> Self:
+        """Create an instance of the class from a cofiguration data"""
+
+    @abstractmethod
+    def export(self, run_result: list[RunResult]) -> None:
+        """Export the results
+        Args:
+            run_result (list[RunResult]): The results to export
+        """
+
+
+class CSVExporter(Exporter):
+    """Exporter that writes results to a CSV file."""
+
+    def __init__(self, output_path: str) -> None:
+        """Initialize the CSVExporter with a filename.
+
+        Args:
+            output_path (str): The path to the CSV file to write to.
+        """
+        self.output_path = output_path
+
+    @classmethod
+    def from_config(cls, config: dict[str, object]) -> Self:
+        """Create a CSVExporter from congiguration data."""
+        return cls(output_path=str(config.get("output_path", "carbon_output.csv")))
+
+    def export(self, run_result: list[RunResult]) -> None:
+        """Export the results to a CSV file. one row per job
+        Args:
+            run_result (list[RunResult]): The results to export
+        """
+        with open(self.output_path, "a", newline="") as csvfile:
+            writer = csv.writer(csvfile)
+            for result in run_result:
+                writer.writerow(
+                    [
+                        result.job.id,
+                        result.job.starttime,
+                        result.job.runtime,
+                        result.job.cputime,
+                        result.job.gputime,
+                        result.job.memtime,
+                        result.node.name,
+                        result.energy_consumed,
+                        result.carbon_intensity,
+                        result.emissions,
+                    ]
+                )

--- a/carbon/exporter.py
+++ b/carbon/exporter.py
@@ -6,11 +6,13 @@ specified region and time period.
 """
 
 import csv
-import os
 from abc import abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol, Self
 
-from carbon import RunResult
+from . import RunResult
+from .clusterconfig import CSVExporterConfig
 
 
 class Exporter(Protocol):
@@ -30,21 +32,18 @@ class Exporter(Protocol):
         """
 
 
+@dataclass
 class CSVExporter(Exporter):
     """Exporter that writes results to a CSV file."""
 
-    def __init__(self, output_path: str) -> None:
-        """Initialize the CSVExporter with a filename.
-
-        Args:
-            output_path (str): The path to the CSV file to write to.
-        """
-        self.output_path = output_path
+    output_path: Path
+    """Path where CSV output will be saved."""
 
     @classmethod
     def from_config(cls, config: dict[str, object]) -> Self:
         """Create a CSVExporter from configuration data."""
-        return cls(output_path=str(config.get("output_path", "carbon_output.csv")))
+        validated_config = CSVExporterConfig.model_validate(config)
+        return cls(output_path=validated_config.output_path)
 
     def export(self, run_result: list[RunResult]) -> None:
         """Export the results.
@@ -52,39 +51,33 @@ class CSVExporter(Exporter):
         Args:
             run_result (list[RunResult]): The results to export.
         """
-        file_exists = (
-            os.path.exists(self.output_path) and os.path.getsize(self.output_path) > 0
-        )
-
-        with open(self.output_path, "a", newline="") as csvfile:
-            writer = csv.writer(csvfile)
-            if not file_exists:
-                writer.writerow(
-                    [
-                        "job_id",
-                        "starttime",
-                        "runtime",
-                        "cputime",
-                        "gputime",
-                        "memtime",
-                        "node",
-                        "energy_breakdown_total_kwh",
-                        "carbon_intensity",
-                        "emissions",
-                    ]
-                )
+        fieldnames = [
+            "job_id",
+            "starttime",
+            "runtime",
+            "cputime",
+            "gputime",
+            "memtime",
+            "node",
+            "energy_breakdown_total_kwh",
+            "carbon_intensity",
+            "emissions",
+        ]
+        with open(self.output_path, "w", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+            writer.writeheader()
             for result in run_result:
                 writer.writerow(
-                    [
-                        result.job.id,
-                        result.job.starttime,
-                        result.job.runtime,
-                        result.job.cputime,
-                        result.job.gputime,
-                        result.job.memtime,
-                        result.node.name,
-                        result.energy_breakdown.total,
-                        result.carbon_intensity,
-                        result.emissions,
-                    ]
+                    dict(
+                        job_id=result.job.id,
+                        starttime=result.job.starttime,
+                        runtime=result.job.runtime,
+                        cputime=result.job.cputime,
+                        gputime=result.job.gputime,
+                        memtime=result.job.memtime,
+                        node=result.node.name,
+                        energy_breakdown_total_kwh=result.energy_breakdown.total,
+                        carbon_intensity=result.carbon_intensity,
+                        emissions=result.emissions,
+                    )
                 )

--- a/carbon/exporter.py
+++ b/carbon/exporter.py
@@ -68,7 +68,7 @@ class CSVExporter(Exporter):
                         "gputime",
                         "memtime",
                         "node",
-                        "energy_consumed",
+                        "energy_breakdown_total_kwh",
                         "carbon_intensity",
                         "emissions",
                     ]
@@ -83,7 +83,7 @@ class CSVExporter(Exporter):
                         result.job.gputime,
                         result.job.memtime,
                         result.node.name,
-                        result.energy_consumed,
+                        result.energy_breakdown.total,
                         result.carbon_intensity,
                         result.emissions,
                     ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,9 @@
 
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import MagicMock
 
+import yaml
 from click.testing import CliRunner
 
 from carbon import RunResult
@@ -107,3 +109,38 @@ def test_cli_aggregate_prints_aggregate(monkeypatch) -> None:
     out = res.output
     assert "Aggregating estimates over multiple jobs." in out
     assert "Estimated energy consumed" in out
+
+
+def test_exporter_config(tmp_path, mocker) -> None:
+    """Test that the CLI passes exporter options from config file."""
+    cfg_in_path = Path(__file__).parents[1] / "clusters" / "dummy.yaml"
+    cfg_path = tmp_path / "test_config.yaml"
+    output_path = tmp_path / "test_output.csv"
+
+    # write new config file with exporter options
+    with open(cfg_in_path) as f:
+        config_data = yaml.safe_load(f)
+    config_data["exporters"] = ["csv"]
+    config_data["exporter_config"] = dict(csv=dict(output_path=str(output_path)))
+    with open(cfg_path, "w") as f:
+        yaml.safe_dump(config_data, f)
+
+    exporter_mock = MagicMock()
+    mocker.patch(
+        "carbon.__main__.get_exporter_classes", return_value=dict(csv=exporter_mock)
+    )
+    results = [make_result("jobA")]
+    mocker.patch("carbon.__main__.run", return_value=results)
+    runner = CliRunner()
+    res = runner.invoke(
+        main,
+        [
+            "--config-path",
+            cfg_path,
+            f"path={output_path}",
+            "jobA",
+        ],
+    )
+    assert res.exit_code == 0
+    exporter_mock.from_config.assert_called_once_with({"output_path": str(output_path)})
+    exporter_mock.from_config().export.assert_called_once_with(results)

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -1,0 +1,67 @@
+"""Unit tests for the exporters."""
+
+import csv
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from carbon.exporter import CSVExporter
+from carbon import RunResult
+from carbon.job import Job
+from carbon.node import Node
+
+
+def make_result(job_id: str) -> RunResult:
+    """Construct a synthetic RunResult for tests using the given job ID.
+
+    The returned RunResult contains a Job and Node with deterministic values
+    suitable for asserting CLI output.
+    """
+    job = Job(
+        id=job_id,
+        starttime=datetime(2025, 10, 26, 23, 43, 39),
+        runtime=1.0,
+        cputime=100.0,
+        gputime=0.0,
+        memtime=100.0,
+        node="cx3-1-1",
+    )
+    node = Node(
+        name="cx3-1-1",
+        cpu_type="x",
+        gpu_type=None,
+        mem_type="m",
+        per_core_power_watts=1.0,
+        per_gpu_power_watts=0.0,
+        per_gb_power_watts=0.5,
+    )
+    return RunResult(
+        node=node, emissions=1.0, energy_consumed=1.0, job=job, carbon_intensity=137.0
+    )
+
+
+def test_csv_exporter_write_rows(tmp_path) -> None:
+    """Test that CSVExporter writes rows to a CSV file."""
+    output_file = tmp_path / "test_output.csv"
+    exporter = CSVExporter(str(output_file))
+    exporter.export([make_result("job1"), make_result("job2")])
+
+    with open(output_file) as csvfile:
+        rows = list(csv.reader(csvfile))
+
+    assert len(rows) == 2
+    assert rows[0][0] == "job1"
+    assert rows[1][0] == "job2"
+
+
+def test_csv_exporter_from_config(tmp_path) -> None:
+    """Test that CSVExporter can be created from configuration."""
+    output_file = tmp_path / "config_output.csv"
+    exporter = CSVExporter.from_config({"output_path": str(output_file)})
+    assert exporter.output_path == str(output_file)
+
+
+def test_csv_exporter_default_output_path() -> None:
+    """Test that CSVExporter uses default output path if not specified."""
+    exporter = CSVExporter.from_config({})
+    assert exporter.output_path == "carbon_output.csv"

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -2,6 +2,7 @@
 
 import csv
 from datetime import datetime
+from pathlib import Path
 
 from carbon import RunResult
 from carbon.exporter import CSVExporter
@@ -46,15 +47,15 @@ def make_result(job_id: str) -> RunResult:
 
 def test_csv_exporter_write_rows(tmp_path) -> None:
     """Test that CSVExporter writes rows to a CSV file."""
-    output_file = tmp_path / "test_output.csv"
-    exporter = CSVExporter(str(output_file))
+    output_path = tmp_path / "test_output.csv"
+    exporter = CSVExporter(output_path)
     exporter.export([make_result("job1"), make_result("job2")])
 
-    with open(output_file) as csvfile:
-        rows = list(csv.reader(csvfile))
+    with open(output_path) as csvfile:
+        rows = list(csv.DictReader(csvfile))
 
-    assert len(rows) == 3  # header + 2 jobs
-    assert rows[0] == [
+    assert len(rows) == 2
+    assert list(rows[0].keys()) == [
         "job_id",
         "starttime",
         "runtime",
@@ -66,43 +67,18 @@ def test_csv_exporter_write_rows(tmp_path) -> None:
         "carbon_intensity",
         "emissions",
     ]
-    assert rows[1][0] == "job1"
-    assert rows[2][0] == "job2"
+    assert rows[0]["job_id"] == "job1"
+    assert rows[1]["job_id"] == "job2"
 
 
 def test_csv_exporter_from_config(tmp_path) -> None:
     """Test that CSVExporter can be created from configuration."""
     output_file = tmp_path / "config_output.csv"
     exporter = CSVExporter.from_config({"output_path": str(output_file)})
-    assert exporter.output_path == str(output_file)
+    assert exporter.output_path == output_file
 
 
 def test_csv_exporter_default_output_path() -> None:
     """Test that CSVExporter uses default output path if not specified."""
     exporter = CSVExporter.from_config({})
-    assert exporter.output_path == "carbon_output.csv"
-
-
-def test_csv_exporter_no_duplicate_header(tmp_path) -> None:
-    """Test that header is not written twice when appending."""
-    output_file = tmp_path / "test_output.csv"
-    exporter = CSVExporter(str(output_file))
-    exporter.export([make_result("job1")])
-    exporter.export([make_result("job2")])
-
-    with open(output_file) as csvfile:
-        rows = list(csv.reader(csvfile))
-
-    assert len(rows) == 3  # header + 2 jobs
-    assert rows[0] == [
-        "job_id",
-        "starttime",
-        "runtime",
-        "cputime",
-        "gputime",
-        "memtime",
-        "node",
-        "energy_breakdown_total_kwh",
-        "carbon_intensity",
-        "emissions",
-    ]
+    assert exporter.output_path == Path("carbon_output.csv")

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -2,11 +2,9 @@
 
 import csv
 from datetime import datetime
-from pathlib import Path
 
-import pytest
-from carbon.exporter import CSVExporter
 from carbon import RunResult
+from carbon.exporter import CSVExporter
 from carbon.job import Job
 from carbon.node import Node
 
@@ -49,9 +47,21 @@ def test_csv_exporter_write_rows(tmp_path) -> None:
     with open(output_file) as csvfile:
         rows = list(csv.reader(csvfile))
 
-    assert len(rows) == 2
-    assert rows[0][0] == "job1"
-    assert rows[1][0] == "job2"
+    assert len(rows) == 3  # header + 2 jobs
+    assert rows[0] == [
+        "job_id",
+        "starttime",
+        "runtime",
+        "cputime",
+        "gputime",
+        "memtime",
+        "node",
+        "energy_consumed",
+        "carbon_intensity",
+        "emissions",
+    ]
+    assert rows[1][0] == "job1"
+    assert rows[2][0] == "job2"
 
 
 def test_csv_exporter_from_config(tmp_path) -> None:
@@ -65,3 +75,28 @@ def test_csv_exporter_default_output_path() -> None:
     """Test that CSVExporter uses default output path if not specified."""
     exporter = CSVExporter.from_config({})
     assert exporter.output_path == "carbon_output.csv"
+
+
+def test_csv_exporter_no_duplicate_header(tmp_path) -> None:
+    """Test that header is not written twice when appending."""
+    output_file = tmp_path / "test_output.csv"
+    exporter = CSVExporter(str(output_file))
+    exporter.export([make_result("job1")])
+    exporter.export([make_result("job2")])
+
+    with open(output_file) as csvfile:
+        rows = list(csv.reader(csvfile))
+
+    assert len(rows) == 3  # header + 2 jobs
+    assert rows[0] == [
+        "job_id",
+        "starttime",
+        "runtime",
+        "cputime",
+        "gputime",
+        "memtime",
+        "node",
+        "energy_consumed",
+        "carbon_intensity",
+        "emissions",
+    ]

--- a/tests/test_exporter.py
+++ b/tests/test_exporter.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from carbon import RunResult
 from carbon.exporter import CSVExporter
 from carbon.job import Job
+from carbon.job.job import EnergyBreakdown
 from carbon.node import Node
 
 
@@ -33,8 +34,13 @@ def make_result(job_id: str) -> RunResult:
         per_gpu_power_watts=0.0,
         per_gb_power_watts=0.5,
     )
+    energy_breakdown = EnergyBreakdown(cpu=0.5, gpu=0.0, memory=0.5, total=1.0)
     return RunResult(
-        node=node, emissions=1.0, energy_consumed=1.0, job=job, carbon_intensity=137.0
+        node=node,
+        emissions=1.0,
+        energy_breakdown=energy_breakdown,
+        job=job,
+        carbon_intensity=137.0,
     )
 
 
@@ -56,7 +62,7 @@ def test_csv_exporter_write_rows(tmp_path) -> None:
         "gputime",
         "memtime",
         "node",
-        "energy_consumed",
+        "energy_breakdown_total_kwh",
         "carbon_intensity",
         "emissions",
     ]
@@ -96,7 +102,7 @@ def test_csv_exporter_no_duplicate_header(tmp_path) -> None:
         "gputime",
         "memtime",
         "node",
-        "energy_consumed",
+        "energy_breakdown_total_kwh",
         "carbon_intensity",
         "emissions",
     ]


### PR DESCRIPTION
# Description

Added an Exporter and CSVExporter that writes job emission results to a csv file. --exporter CLI flag or configured as defaults in cluster config

Fixes #232

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
